### PR TITLE
Optimize `clear()` method in RedisCacheEngine and add Docker config

### DIFF
--- a/.run/Services for Test.run.xml
+++ b/.run/Services for Test.run.xml
@@ -1,0 +1,10 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Services for Test" type="docker-deploy" factoryName="docker-compose.yml" server-name="Docker">
+    <deployment type="docker-compose.yml">
+      <settings>
+        <option name="sourceFilePath" value="docker-compose.yml" />
+      </settings>
+    </deployment>
+    <method v="2" />
+  </configuration>
+</component>

--- a/src/Psr16/RedisCacheEngine.php
+++ b/src/Psr16/RedisCacheEngine.php
@@ -159,12 +159,13 @@ class RedisCacheEngine extends BaseCacheEngine implements AtomicOperationInterfa
     #[\Override]
     public function clear(): bool
     {
-        $keys = $this->redis->keys('cache:*');
-        foreach ($keys as $key) {
-            if (preg_match('/^cache:(?<key>.*)/', $key, $matches)) {
-                $this->delete($matches['key']);
+        $iterator = null;
+        do {
+            $keys = $this->redis->scan($iterator, 'cache:*');
+            foreach($keys as $key) {
+                $this->delete(substr($key, 6));
             }
-        }
+        } while($iterator !== 0);
         return true;
     }
 


### PR DESCRIPTION
- **What is the purpose of this pull request?**
  - Optimizes the `clear()` method in `RedisCacheEngine` by using the SCAN command for improved performance.
  - Adds a Docker service run configuration to facilitate testing.

- **Why is this necessary?**
  - To enhance the performance of the `clear()` operation in the Redis Cache Engine.
  - To simplify and streamline the test setup process.

- [ ] Unit tests
- [ ] Integration tests
- [ ] Documentation